### PR TITLE
Add TutorialSearch to Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A curated collection of resources for frontend developers preparing for intervie
 
 - [Articles/Blogs resources related to React](https://reactresources.com/articles)
 - [React with webpack resource](https://www.packtpub.com/product/hands-on-webpack-for-react-development-video/9781789139808)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A curated collection of resources for frontend developers preparing for intervie
 
 - [Articles/Blogs resources related to React](https://reactresources.com/articles)
 - [React with webpack resource](https://www.packtpub.com/product/hands-on-webpack-for-react-development-video/9781789139808)
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/web-development/front-end-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ---
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Learning Resources* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/web-development/front-end-development) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/web-development/front-end-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.